### PR TITLE
Add X, Y, s parameters to ntedit-make

### DIFF
--- a/ntedit-make
+++ b/ntedit-make
@@ -24,8 +24,6 @@ m=0
 v=0
 a=0
 j=3
-X=
-Y=
 
 SHELL=bash -e -o pipefail
 ifeq ($(shell zsh -e -o pipefail -c 'true' 2>/dev/null; echo $$?), 0)
@@ -126,14 +124,14 @@ else
 endif
 
 ifdef X
-	Y?=0.5
+Y?=0.5
 endif
 ifdef Y
-	X?=0.5
+X?=0.5
 endif
 $(draftPrefix)_k$k_edited.fa: $p_k$k.bf $(draft)
 ifdef X
-	$(gtimeNtedit) ntedit -r $< -f $(word 2,$^) -b $b -t $t -z $z -i $i -d $d -x $x -y $y -c $(cap) -m $m -v $v -a $a -j $j -X$X -Y$Y
+	$(gtimeNtedit) ntedit -r $< -f $(word 2,$^) -b $b -t $t -z $z -i $i -d $d -x $x -y $y -c $(cap) -m $m -v $v -a $a -j $j -X $X -Y $Y
 else
 	$(gtimeNtedit) ntedit -r $< -f $(word 2,$^) -b $b -t $t -z $z -i $i -d $d -x $x -y $y -c $(cap) -m $m -v $v -a $a -j $j
 endif

--- a/ntedit-make
+++ b/ntedit-make
@@ -24,6 +24,8 @@ m=0
 v=0
 a=0
 j=3
+X=
+Y=
 
 SHELL=bash -e -o pipefail
 ifeq ($(shell zsh -e -o pipefail -c 'true' 2>/dev/null; echo $$?), 0)
@@ -77,6 +79,8 @@ help:
 	@echo "	y	k/y ratio for the number of editted kmers that should be present, [default=9.000]"
 	@echo "	j	controls size of kmer subset. When checking subset of kmers, check every jth kmer, [default=3]"
 	@echo "	cap	cap for the number of base insertions that can be made at one position, [default=k*1.5]"
+	@echo "	X	ratio of number of kmers in the k subset that should be missing in order to attempt fix (higher=stringent), [default=0.5]"
+	@echo "	Y	ratio of number of kmers in the k subset that should be present to accept an edit (higher=stringent), [default=0.5]"
 	@echo "	m	mode of editing, range 0-2, [default=0]"
 	@echo "			0: best substitution, or first good indel"
 	@echo "			1: best substitution, or best indel"
@@ -91,6 +95,7 @@ help:
 	@echo "Make sure your read files all have the same prefix, as indicated by 'reads=<prefix>'. The makefile will use all files in the current working directory with this prefix for polishing."
 	@echo "To ensure that the pipeline runs correctly, make sure that the following tools are in your PATH: ntedit, nthits"
 	@echo "You must either specify the cutoff parameter or define solid=true in your command to set it automatically"
+	@echo "If one of X/Y is set, ntEdit will use those parameters instead. Otherwise, it uses x/y by default."
 
 #Run ntEdit
 ntedit: check $(draftPrefix)_k$k_edited.fa
@@ -120,5 +125,15 @@ else
 	$(gtimeNthits) nthits -c$(cutoff) --outbloom -p$p -k$k -t$t $^
 endif
 
+ifdef X
+	Y?=0.5
+endif
+ifdef Y
+	X?=0.5
+endif
 $(draftPrefix)_k$k_edited.fa: $p_k$k.bf $(draft)
+ifdef X
+	$(gtimeNtedit) ntedit -r $< -f $(word 2,$^) -b $b -t $t -z $z -i $i -d $d -x $x -y $y -c $(cap) -m $m -v $v -a $a -j $j -X$X -Y$Y
+else
 	$(gtimeNtedit) ntedit -r $< -f $(word 2,$^) -b $b -t $t -z $z -i $i -d $d -x $x -y $y -c $(cap) -m $m -v $v -a $a -j $j
+endif

--- a/ntedit-make
+++ b/ntedit-make
@@ -24,6 +24,7 @@ m=0
 v=0
 a=0
 j=3
+s=0
 
 SHELL=bash -e -o pipefail
 ifeq ($(shell zsh -e -o pipefail -c 'true' 2>/dev/null; echo $$?), 0)
@@ -84,6 +85,7 @@ help:
 	@echo "			1: best substitution, or best indel"
 	@echo "			2: best edit overall (suggestion that you reduce i and d for performance)"
 	@echo "	a	Soft masks missing kmer positions having no fix (-v 1 = yes, default = 0, no)"
+	@echo "	s	SNV mode. Overrides draft kmer checks, forcing reassessment at each position (1 = yes, default = 0, no. EXPERIMENTAL)"
 	@echo "	v	verbose mode (1 = yes, default = 0, no)"
 	@echo ""
 	@echo "Example: Polishing myDraft.fa with myReads1.fq and myReads2.fq"
@@ -131,7 +133,7 @@ X?=0.5
 endif
 $(draftPrefix)_k$k_edited.fa: $p_k$k.bf $(draft)
 ifdef X
-	$(gtimeNtedit) ntedit -r $< -f $(word 2,$^) -b $b -t $t -z $z -i $i -d $d -x $x -y $y -c $(cap) -m $m -v $v -a $a -j $j -X $X -Y $Y
+	$(gtimeNtedit) ntedit -r $< -f $(word 2,$^) -b $b -t $t -z $z -i $i -d $d -x $x -y $y -c $(cap) -m $m -v $v -a $a -j $j -X $X -Y $Y -s $s
 else
-	$(gtimeNtedit) ntedit -r $< -f $(word 2,$^) -b $b -t $t -z $z -i $i -d $d -x $x -y $y -c $(cap) -m $m -v $v -a $a -j $j
+	$(gtimeNtedit) ntedit -r $< -f $(word 2,$^) -b $b -t $t -z $z -i $i -d $d -x $x -y $y -c $(cap) -m $m -v $v -a $a -j $j -s $s
 endif


### PR DESCRIPTION
* added `X`, `Y` parameters to `ntedit-make`
  * If one is specified, override both `x` and `y`
* added `s` parameter to `ntedit-make`

@warrenlr  - note that I didn't add `e` yet, just because it's a little bit more involved. I'm happy to do that in a future PR if it's helpful, though!