### PR TITLE
Avoid use of single-character parameters to snakemake file

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ jobs:
         displayName: Create Anaconda environment
       - script: |
           source activate ntedit_CI
-          conda install --yes -c conda-forge mamba python=3.9
+          conda install --yes -c conda-forge mamba python
           mamba install --yes -c conda-forge -c bioconda libcxx llvm clang compilers=1.7.0 meson ninja btllib make clang-tools perl zlib nthits ntcard boost snakemake cmake
         displayName: Install dependencies
       - script: |
@@ -42,7 +42,7 @@ jobs:
         displayName: Create Anaconda environment
       - script: |
           source activate ntedit_CI
-          conda install --yes -c conda-forge mamba python=3.9
+          conda install --yes -c conda-forge mamba python
           mamba install --yes -c conda-forge -c bioconda compilers=1.7.0 llvm-openmp make btllib perl zlib clang-tools meson ninja nthits ntcard boost snakemake cmake
         displayName: Install dependencies
       - script: |

--- a/ntedit_run_pipeline.smk
+++ b/ntedit_run_pipeline.smk
@@ -6,7 +6,7 @@ import os
 # Read parameters from config or set default values
 draft=config["draft"]
 reads_prefix=config["reads"] if "reads" in config else ""
-k=config["k"]
+k=config["kmer"]
 
 # ancestry parameters
 genomes = config["genomes"] if "genomes" in config else ""
@@ -34,30 +34,30 @@ if k <= 0:
     raise ValueError("k must be greater than 0.")
 
 # Common parameters
-t = config["t"] if "t" in config else 4
-b = config["b"] + "_" if "b" in config and config["b"] != "" else ""
+t = config["threads"] if "threads" in config else 4
+b = config["b_prefix"] + "_" if "b_prefix" in config and config["b_prefix"] != "" else ""
 
 # ntHits parameters
 solid = config["solid"] if "solid" in config else False
 cutoff = config["cutoff"] if "cutoff" in config else 2
 
 # ntEdit parameters
-z = config["z"] if "z" in config else 100
-i = config["i"] if "i" in config else 5
-d = config["d"] if "d" in config else 5
-x = config["x"] if "x" in config else 5.000
-y = config["y"] if "y" in config else 9.000
+z = config["z_param"] if "z_param" in config else 100
+i = config["i_param"] if "i_param" in config else 5
+d = config["d_param"] if "d_param" in config else 5
+x = config["x_param"] if "x_param" in config else 5.000
+y = config["y_param"] if "y_param" in config else 9.000
 cap = config["cap"] if "cap" in config else (int(k * 3 / 2) if k is not None else None)
-m = config["m"] if "m" in config else 0
-v = config["v"] if "v" in config else 0
-a = config["a"] if "a" in config else 0
-j = config["j"] if "j" in config else 3
-s = config["s"] if "s" in config else 0
-X = config["X"] if "X" in config else -1
-Y = config["Y"] if "Y" in config else -1
-p = config["p"] if "p" in config else 1
-q = config["q"] if "q" in config else 255
-l = config["l"] if "l" in config else ""
+m = config["m_param"] if "m_param" in config else 0
+v = config["verbose"] if "verbose" in config else 0
+a = config["a_param"] if "a_param" in config else 0
+j = config["j_param"] if "j_param" in config else 3
+s = config["s_param"] if "s_param" in config else 0
+X = config["X_param"] if "X_param" in config else -1
+Y = config["Y_param"] if "Y_param" in config else -1
+p = config["p_param"] if "p_param" in config else 1
+q = config["q_param"] if "q_param" in config else 255
+l = config["l_vcf"] if "l_vcf" in config else ""
 
 
 if l != "":

--- a/run-ntedit
+++ b/run-ntedit
@@ -159,8 +159,8 @@ def main():
         intro_string.append(f"\t--draft {args.draft}")
 
     command = f"snakemake -s {base_dir}/ntedit_run_pipeline.smk {smk_rule} -p --cores {args.t} " \
-            f"--config draft={input_genome} k={args.k} t={args.t} " \
-            f"z={args.z} y={args.y} v={args.v} j={args.j} "
+            f"--config draft={input_genome} kmer={args.k} threads={args.t} " \
+            f"z_param={args.z} y_param={args.y} j_param={args.j} "
 
     if args.mode == "snv" and args.genome:
         intro_string.append(f"\t--genome {args.genome}")
@@ -182,7 +182,7 @@ def main():
             args.Y = 0.5
         intro_string.append(f"\t-X {args.X}")
         intro_string.append(f"\t-Y {args.Y}")
-        command += f" X={args.X} Y={args.Y}"
+        command += f" X_param={args.X} Y_param={args.Y}"
 
     if not (args.mode == "snv" and args.genome):
         if args.solid:
@@ -194,15 +194,15 @@ def main():
 
     if args.v:
         intro_string.append("\t-v")
-        command += " v=1"
+        command += " verbose=1"
     else:
-        command += " v=0"
+        command += " verbose=0"
  
     if args.l:
         if not os.path.isfile(args.l):
             raise FileNotFoundError(f"VCF file {args.l} not found")
         intro_string.append(f"\t-l {args.l}")
-        command += f" l={args.l}"
+        command += f" l_vcf={args.l}"
 
     # Polishing-specific parameter logs
     if args.mode == "polish":
@@ -214,7 +214,7 @@ def main():
         intro_string.append(f"\t-x {args.x}")
         intro_string.append(f"\t-m {args.m}")
         intro_string.append(f"\t-a {args.a}")
-        command += f" i={args.i} d={args.d} x={args.x} m={args.m} a={args.a} "
+        command += f" i_param={args.i} d_param={args.d} x_param={args.x} m_param={args.m} a_param={args.a} "
 
     # SNV / Ancestry-specific parameter logs
     if args.mode == "snv":


### PR DESCRIPTION
* As reported in https://github.com/snakemake/snakemake/issues/3015 and mentioned in #65, there seems to be an issue with snakemake v8.17.0+ parsing single-character config parameters
* To avoid this issue without pinning an older snakemake version, edited all single-character config keys to the snakemake file to use multi-character strings instead