### PR TITLE
Fix macOS CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,16 +36,16 @@ jobs:
     pool:
       vmImage: macOS-latest
     steps:
-    - script: |
-        mkdir -p ~/miniforge3
-        curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
-        bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
-        rm -rf  ~/miniforge3/miniforge.sh
-        ~/miniforge3/bin/conda init bash
-        ~/miniforge3/bin/conda init zsh
-        export CONDA=$(realpath ~/miniforge3/bin)
-        echo "##vso[task.prependpath]$CONDA"
-      displayName: Install conda
+      - script: |
+          mkdir -p ~/miniforge3
+          curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
+          bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
+          rm -rf  ~/miniforge3/miniforge.sh
+          ~/miniforge3/bin/conda init bash
+          ~/miniforge3/bin/conda init zsh
+          export CONDA=$(realpath ~/miniforge3/bin)
+          echo "##vso[task.prependpath]$CONDA"
+        displayName: Install conda
       - script: conda create --yes --quiet --name ntedit_CI
         displayName: Create Anaconda environment
       - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,13 +36,21 @@ jobs:
     pool:
       vmImage: macOS-latest
     steps:
-      - script: echo "##vso[task.prependpath]$CONDA/bin"
-        displayName: Add conda to PATH
+    - script: |
+        mkdir -p ~/miniforge3
+        curl -L https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh  -o ~/miniforge3/miniforge.sh
+        bash ~/miniforge3/miniforge.sh -b -u -p ~/miniforge3
+        rm -rf  ~/miniforge3/miniforge.sh
+        ~/miniforge3/bin/conda init bash
+        ~/miniforge3/bin/conda init zsh
+        export CONDA=$(realpath ~/miniforge3/bin)
+        echo "##vso[task.prependpath]$CONDA"
+      displayName: Install conda
       - script: conda create --yes --quiet --name ntedit_CI
         displayName: Create Anaconda environment
       - script: |
           source activate ntedit_CI
-          conda install --yes -c conda-forge mamba python
+          mamba install --yes -c conda-forge python
           mamba install --yes -c conda-forge -c bioconda compilers=1.7.0 llvm-openmp make btllib perl zlib clang-tools meson ninja nthits ntcard boost snakemake cmake
         displayName: Install dependencies
       - script: |


### PR DESCRIPTION
* Recently, macOS-latest VM was updated to use macOS-14
  * This VM no longer has conda installed by default
* Workaround is to install miniforge as part of the CI
  * This already has mamba, which is a side benefit