### PR TITLE
Fix CI - pin python version for ubuntu

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
           meson build --prefix=$(pwd)/test_build
           cd build
           ninja install
-        displayName: Compile ntedit
+        displayName: Compile ntEdit
       - script: |
           source activate ntedit_CI
           make clang-format
@@ -58,7 +58,7 @@ jobs:
           meson build --prefix=$(pwd)/test_build
           cd build
           ninja install
-        displayName: Compile ntedit
+        displayName: Compile ntEdit
       - script: |
           source activate ntedit_CI
           export PATH=$(pwd)/test_build/bin:$PATH

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,8 +12,7 @@ jobs:
         displayName: Create Anaconda environment
       - script: |
           source activate ntedit_CI
-          conda install --yes -c conda-forge mamba python
-          mamba install --yes -c conda-forge -c bioconda libcxx llvm clang compilers=1.7.0 meson ninja btllib make clang-tools perl zlib nthits ntcard boost snakemake cmake
+          mamba install --yes -c conda-forge -c bioconda python libcxx llvm clang compilers=1.7.0 meson ninja btllib make clang-tools perl zlib nthits ntcard boost snakemake cmake
         displayName: Install dependencies
       - script: |
           source activate ntedit_CI
@@ -50,8 +49,7 @@ jobs:
         displayName: Create Anaconda environment
       - script: |
           source activate ntedit_CI
-          mamba install --yes -c conda-forge python
-          mamba install --yes -c conda-forge -c bioconda compilers=1.7.0 llvm-openmp make btllib perl zlib clang-tools meson ninja nthits ntcard boost snakemake cmake
+          mamba install --yes -c conda-forge -c bioconda python compilers=1.7.0 llvm-openmp make btllib perl zlib clang-tools meson ninja nthits ntcard boost snakemake cmake
         displayName: Install dependencies
       - script: |
           source activate ntedit_CI

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,8 @@ jobs:
         displayName: Create Anaconda environment
       - script: |
           source activate ntedit_CI
-          mamba install --yes -c conda-forge -c bioconda python libcxx llvm clang compilers=1.7.0 meson ninja btllib make clang-tools perl zlib nthits ntcard boost snakemake cmake
+          conda install --yes -c conda-forge mamba python=3.12
+          mamba install --yes -c conda-forge -c bioconda libcxx llvm clang compilers=1.7.0 meson ninja btllib make clang-tools perl zlib nthits ntcard boost snakemake cmake
         displayName: Install dependencies
       - script: |
           source activate ntedit_CI


### PR DESCRIPTION
* For linux, python 3.13 is now the default version being installed with conda
  * Currently, bioconda packages are not compiled for python 3.13, which causes issues when installing all dependencies
* Pin python to 3.12 for linux CI for now to avoid errors